### PR TITLE
Fix status code

### DIFF
--- a/internal/app/http/rest/webhook.go
+++ b/internal/app/http/rest/webhook.go
@@ -47,5 +47,5 @@ func (h *WebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	w.WriteHeader(http.StatusOK)
+	w.WriteHeader(http.StatusNoContent)
 }

--- a/internal/app/http/rest/webhook_test.go
+++ b/internal/app/http/rest/webhook_test.go
@@ -1,0 +1,87 @@
+package rest_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/italolelis/watchops/internal/app/http/rest"
+	"github.com/italolelis/watchops/internal/app/wh"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type simpleConnector struct{ shoudlError bool }
+
+func (c *simpleConnector) Write(ctx context.Context, payload []byte, headers map[string][]string) error {
+	if c.shoudlError {
+		return fmt.Errorf("connector error")
+	}
+
+	return nil
+}
+
+type wrongBody struct{}
+
+func (wrongBody) Read(p []byte) (n int, err error) {
+	return 0, errors.New(`everything is broken /o\`)
+}
+
+func TestWebhookHandler(t *testing.T) {
+	cases := []struct {
+		name       string
+		token      func() *http.Request
+		connector  wh.Connector
+		body       io.Reader
+		statusCode int
+	}{
+		{
+			name:       "valid incoming request",
+			connector:  &simpleConnector{},
+			body:       strings.NewReader(`{"foo": "bar"}`),
+			statusCode: http.StatusNoContent,
+		},
+		{
+			name:       "failed connector",
+			connector:  &simpleConnector{true},
+			body:       strings.NewReader(`{"foo": "bar"}`),
+			statusCode: http.StatusInternalServerError,
+		},
+		{
+			name:       "empty body",
+			connector:  &simpleConnector{true},
+			body:       wrongBody{},
+			statusCode: http.StatusBadRequest,
+		},
+		{
+			name:       "invalid body",
+			connector:  &simpleConnector{true},
+			body:       strings.NewReader(``),
+			statusCode: http.StatusInternalServerError,
+		},
+	}
+
+	for _, c := range cases {
+		c := c
+
+		t.Run(c.name, func(t *testing.T) {
+			req, err := http.NewRequest("GET", "/webhooks", c.body)
+			require.NoError(t, err)
+
+			wh := rest.NewWebhookHandler(c.connector)
+
+			rr := httptest.NewRecorder()
+			handler := http.HandlerFunc(wh.HandleWebhook)
+
+			handler.ServeHTTP(rr, req)
+
+			assert.Equal(t, c.statusCode, rr.Code)
+		})
+	}
+
+}

--- a/internal/app/provider/opsgenie/parser.go
+++ b/internal/app/provider/opsgenie/parser.go
@@ -64,7 +64,7 @@ func (p *Parser) Parse(headers map[string][]string, payload []byte) (provider.Ev
 		event.ID = e.Alert.ID
 
 		if e.Alert.UpdatedAt > 0 {
-			event.TimeCreated = time.Unix(e.Alert.UpdatedAt, 0)
+			event.TimeCreated = time.UnixMilli(e.Alert.UpdatedAt)
 		} else {
 			event.TimeCreated = time.Now()
 		}
@@ -73,7 +73,7 @@ func (p *Parser) Parse(headers map[string][]string, payload []byte) (provider.Ev
 		event.ID = e.EscalationID
 
 		if e.EsclationTime > 0 {
-			event.TimeCreated = time.Unix(e.EsclationTime, 0)
+			event.TimeCreated = time.UnixMilli(e.EsclationTime)
 		} else {
 			event.TimeCreated = time.Now()
 		}

--- a/internal/app/provider/opsgenie/parser_test.go
+++ b/internal/app/provider/opsgenie/parser_test.go
@@ -22,7 +22,7 @@ func TestParsePayload(t *testing.T) {
 			expectedObject: provider.Event{
 				ID:          "f3efa74b-29cc-4a4f-9bb7-804d7c1be544-1639476708514",
 				EventType:   "AddNote",
-				TimeCreated: time.Unix(1639521280284000000, 0),
+				TimeCreated: time.UnixMilli(1639521280284000000),
 				Signature:   "l1Q61kXRlCp_qTIudME8AfYmVtY=",
 				MsgID:       "testID",
 				Source:      "opsgenie",


### PR DESCRIPTION
Fixes a problem with the `/webhooks` endpoint returning a 200 instead of 204. 
Fixes a bug in the opsgenie parser where we tried to parse a UNIX timestamp with the wrong precision.

## Pull request type

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

* The `/webhooks` endpoint returns 200.
* OpsGenie calls fail because of the wrong timestamp parsing.

## What is the new behavior?

- The `/webhooks` endpoint returns 204.
- OpsGenie calls should start working now.
